### PR TITLE
removing innecesary parameter shared

### DIFF
--- a/doc/fermi-man/chapter3.tex
+++ b/doc/fermi-man/chapter3.tex
@@ -87,7 +87,6 @@ Pseudocode for this instance:
   tag = 100
   int status
   
-  error = MPI_Recv (&\textcolor{OliveGreen}{t_0}, 1, MPI_DOUBLE_PRECISION, 0, tag, Comp_Comm, &status)
   error = MPI_Recv (&\textcolor{OliveGreen}{N_t}, 1, MPI_INTEGER, 0, tag, Comp_Comm, &status)
   error = MPI_Recv (&\textcolor{OliveGreen}{N_input_var}, 1, MPI_INTEGER, 0, tag, Comp_Comm, &status)
   error = MPI_Recv (&\textcolor{OliveGreen}{N_output_var}, 1, MPI_INTEGER, 0, tag, Comp_Comm, &status)


### PR DESCRIPTION
Quité el parámetro t0.
Los únicos parámetros necesarios a intercambiar son la cantidad de steps, la cantidad de parámetros a enviar en cada step y la cantidad de parámetros a recibir en cada step.